### PR TITLE
Bypass @root when using a qualified URL for CSS

### DIFF
--- a/lib/deadweight.rb
+++ b/lib/deadweight.rb
@@ -144,7 +144,11 @@ class Deadweight
   def fetch(path)
     log.puts(path)
 
-    loc = root + path
+	if path.match(/^(f|ht)tp/)
+		loc = path
+	else
+		loc = root + path
+	end
 
     if @mechanize
       loc = "file://#{File.expand_path(loc)}" unless loc =~ %r{^\w+://}


### PR DESCRIPTION
Allows calls like 

<pre>
deadweight --root http://www.example.com -s '/css/style.css' -s 'http://www2.example.com/css/style2.css' /
</pre>
