### PR TITLE
Add media_root attribute for sites served on multiple domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ There are multiple ways to use Deadweight. It's designed to be completely agnost
     $ deadweight -s styles.css -s ie.css index.html about.html
     $ deadweight -s http://www.tigerbloodwins.com/index.css http://www.tigerbloodwins.com/
     $ deadweight --root http://kottke.org/ -s '/templates/2009/css.php?p=mac' / /everfresh /about
+    $ deadweight --root http://myserver.com/ --media_root http://media.myserver.com -s '/perfect_css.css' / /bio
 
 ### Integrate it With Your Integration Tests ###
 
@@ -45,9 +46,9 @@ Let me know how it goes. It's not terribly customisable at the moment (you can't
 ### Rake Task ###
 
     # lib/tasks/deadweight.rake
-  
+
     require 'deadweight'
-  
+
     Deadweight::RakeTask.new do |dw|
       dw.stylesheets = ["/stylesheets/style.css"]
       dw.pages = ["/", "/page/1", "/about"]
@@ -58,7 +59,7 @@ Running `rake deadweight` will output all unused rules, one per line. Note that 
 ### Call it Directly from Ruby ###
 
     require 'deadweight'
-  
+
     dw = Deadweight.new
     dw.stylesheets = ["/stylesheets/style.css"]
     dw.pages = ["/", "/page/1", "/about"]
@@ -80,6 +81,11 @@ By default, Deadweight uses `http://localhost:3000` as the base URL for all path
     dw.root = "http://staging.example.com"      # staging server
     dw.root = "http://example.com/staging-area" # urls can have paths in
     dw.root = "/path/to/some/html"              # local paths work too
+
+The `media root` attribute can be used for situations where CSS is being
+served on a different doamin than the HTML:
+
+    dw.media_root = "http://media.example.com"
 
 What About Stuff Added by Javascript?
 -------------------------------------

--- a/lib/deadweight.rb
+++ b/lib/deadweight.rb
@@ -15,11 +15,12 @@ rescue LoadError
 end
 
 class Deadweight
-  attr_accessor :root, :stylesheets, :rules, :pages, :ignore_selectors, :mechanize, :log_file
+  attr_accessor :root, :media_root, :stylesheets, :rules, :pages, :ignore_selectors, :mechanize, :log_file
   attr_reader :unused_selectors, :parsed_rules
 
   def initialize
     @root = 'http://localhost:3000'
+    @media_root = nil
     @stylesheets = []
     @pages = []
     @rules = ""
@@ -71,7 +72,7 @@ class Deadweight
     @unused_selectors = []
 
     @stylesheets.each do |path|
-      new_selector_count = add_css!(fetch(path))
+      new_selector_count = add_css!(fetch(path, "media"))
       log.puts("  found #{new_selector_count} selectors".yellow)
     end
 
@@ -141,10 +142,14 @@ class Deadweight
   end
 
   # Fetch a path, using Mechanize if +mechanize+ is set to +true+.
-  def fetch(path)
+  def fetch(path, type = "html")
     log.puts(path)
 
-    loc = root + path
+    if media_root && type == "media"
+      loc = media_root + path
+    else
+      loc = root + path
+    end
 
     if @mechanize
       loc = "file://#{File.expand_path(loc)}" unless loc =~ %r{^\w+://}

--- a/lib/deadweight/cli.rb
+++ b/lib/deadweight/cli.rb
@@ -10,6 +10,7 @@ class Deadweight
     def self.execute(stdout, stdin, stderr, arguments = [])
       @options = {
         :root       => "",
+        :media_root => nil,
         :log_file   => stderr,
         :output     => stdout,
         :proxy_port => 8002
@@ -53,8 +54,13 @@ class Deadweight
         end
 
         opts.on("-r", "--root URL-OR-PATH",
-                "Specify a root for all urls/paths") do |r|
-          @options[:root] = r
+                "Specify a root for all paths") do |r|
+           @options[:root] = r
+        end
+
+        opts.on("-m", "--media_root URL-OR-PATH",
+                "Specify a root for all CSS files") do |m|
+            @options[:media_root] = m
         end
 
         opts.on("-w", "--whitelist URL-PREFIX",
@@ -96,6 +102,8 @@ class Deadweight
       # TODO this should be the default
       dw.root = options[:root]
 
+      dw.media_root = options[:media_root]
+
       dw.log_file = options[:log_file]
 
       dw.stylesheets = options[:stylesheets]
@@ -119,6 +127,8 @@ class Deadweight
 
       # TODO note the boilerplate shared with #process
       dw.root = options[:root]
+
+      dw.media_root = options[:media_root]
       dw.log_file = options[:log_file]
       dw.stylesheets = options[:stylesheets]
       dw.rules = stdin.read if stdin.stat.size > 0

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -17,5 +17,19 @@ class CliTest < Test::Unit::TestCase
       assert_correct_selectors_in_output(`#{COMMAND} #{arg} test/fixtures -s /style.css /index.html 2>/dev/null`)
     end
   end
+
+  should "accept a [-m | --media_root] argument and relative paths" do
+    %w(-m --media_root).each do |arg|
+      assert_correct_selectors_in_output(`#{COMMAND} #{arg} test/fixtures -s /style.css test/fixtures/index.html 2>/dev/null`)
+    end
+  end
+
+  should "accept a [-m | --media_root] argument, along with a [-r | --root] argument and relative paths for each" do
+    %w(-m --media_root).each do |media_arg|
+      %w(-r --root).each do |root_arg|
+        assert_correct_selectors_in_output(`#{COMMAND} #{root_arg} test/fixtures #{media_arg} test/fixtures -s /style.css /index.html 2>/dev/null`)
+      end
+    end
+  end
 end
 

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
 
 class CliTest < Test::Unit::TestCase
   COMMAND      = "ruby -rubygems -Ilib bin/deadweight"

--- a/test/deadweight_test.rb
+++ b/test/deadweight_test.rb
@@ -19,6 +19,7 @@ class DeadweightTest < Test::Unit::TestCase
     should "have the same attributes" do
       assert_equal(@dw.log_file,    @dwb.log_file)
       assert_equal(@dw.root,        @dwb.root)
+      assert_equal(@dw.media_root,  @dwb.media_root)
       assert_equal(@dw.stylesheets, @dwb.stylesheets)
       assert_equal(@dw.pages,       @dwb.pages)
     end

--- a/test/deadweight_test.rb
+++ b/test/deadweight_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
 
 class DeadweightTest < Test::Unit::TestCase
   def setup

--- a/test/rake_task_test.rb
+++ b/test/rake_task_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
 require 'rake'
 
 class RakeTaskTest < Test::Unit::TestCase

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -41,6 +41,7 @@ class Test::Unit::TestCase
   def default_settings(dw)
     dw.log_file = 'test.log'
     dw.root = File.dirname(__FILE__) + '/fixtures'
+    dw.media_root = nil
     dw.stylesheets << '/style.css'
     dw.pages << '/index.html'
   end


### PR DESCRIPTION
Similar to [pull request #10](https://github.com/aanand/deadweight/pull/10), but easier for the use case of someone serving media files from a different domain. Example: Apache serving pages at www.domain.com and Nginx serving media on media.domain.com.  

By setting a media_root attribute, all CSS files will be processed using the media_root and HTML will be processed with the normal root.

Also included:
- Test for the media_root attribute. I didn't want to mess with your directory structure too much to provide a separate media_root folder, but if you have a suggestion for doing this better, let me know and I'll update it.
- Documentation update
- Updates to require statements in tests. I was having trouble running them from the root level on my machine. I think this should work more universally.
- A little whitespace cleanup :)
