### PR TITLE
Support for CSS selectors Level 3 and 4

### DIFF
--- a/lib/deadweight.rb
+++ b/lib/deadweight.rb
@@ -176,7 +176,8 @@ private
   end
 
   def strip(selector)
-    selector.gsub(/::?[\w\-]+/, '')
+    selector.gsub(/^@.*/, '') # @-webkit-keyframes ...
+            .gsub(/:.*/, '') # input#x:nth-child(2):not(#z.o[type='file'])
   end
 
   def log

--- a/test/deadweight_test.rb
+++ b/test/deadweight_test.rb
@@ -37,6 +37,12 @@ class DeadweightTest < Test::Unit::TestCase
 
     # #rab:hover::selection (#rab does not exist)
     assert @result.include?('#rab:hover::selection')
+
+    # input#fancy:nth-child(2):not(#z.o[type='file']) (input#fancy does exist)
+    assert !@result.include?("input#fancy:nth-child(2):not(#z.o[type='file'])")
+
+    # @-webkit-keyframes (ignore)
+    assert !@result.include?("@-webkit-keyframes")
   end
 
   should "accept Procs as targets" do

--- a/test/fixtures/index.html
+++ b/test/fixtures/index.html
@@ -11,6 +11,7 @@
         </div>
 
         <a href="index2.html">next</a>
+        <input type='submit' id='fancy'>ok</input>
     </body>
 </html>
 

--- a/test/fixtures/style.css
+++ b/test/fixtures/style.css
@@ -22,3 +22,9 @@
 #rab:hover::selection {
     color: black;
 }
+
+input#fancy:nth-child(2):not(#z.o[type='file']) {
+    color: red;
+}
+
+@-webkit-keyframes rainbow {}


### PR DESCRIPTION
Hi Annand,

deadweight breaks when CSS files have selectors like these:

```
a.button:not(:disabled):hover { ... }
@-webkit-keyframes appear { ... }
```

This patch fixes it.
