### PR TITLE
Deadweight#strip strips whitespace

### DIFF
--- a/lib/deadweight.rb
+++ b/lib/deadweight.rb
@@ -176,7 +176,7 @@ private
   def strip(selector)
     selector = selector.gsub(/^@.*/, '') # @-webkit-keyframes ...
     selector = selector.gsub(/:.*/, '')  # input#x:nth-child(2):not(#z.o[type='file'])
-    selector
+    selector.strip
   end
 
   def log

--- a/test/deadweight_test.rb
+++ b/test/deadweight_test.rb
@@ -36,7 +36,7 @@ class DeadweightTest < Test::Unit::TestCase
     assert !@result.include?('#foo:hover')
 
     # #rab:hover::selection (#rab does not exist)
-    assert @result.include?('#rab:hover::selection')
+    assert @result.include?('#rab ::selection')
 
     # input#fancy:nth-child(2):not(#z.o[type='file']) (input#fancy does exist)
     assert !@result.include?("input#fancy:nth-child(2):not(#z.o[type='file'])")

--- a/test/fixtures/style.css
+++ b/test/fixtures/style.css
@@ -19,7 +19,7 @@
     color: white;
 }
 
-#rab:hover::selection {
+#rab ::selection {
     color: black;
 }
 


### PR DESCRIPTION
Selectors like `.foo ::-webkit-input-placeholder` were causing Nokogiri to throw an exception. Specifically, `Deadweight#strip` would remove the `::-webkit-input-placeholder`, leaving a trailing whitespace, which Nokogiri doesn't like.

The error message looks something like `Nokogiri::CSS::SyntaxError: unexpected '$' after 'DESCENDANT_SELECTOR'`.
