### PR TITLE
Fix issue with javascript link selector in bootstrap

### DIFF
--- a/lib/deadweight.rb
+++ b/lib/deadweight.rb
@@ -175,7 +175,7 @@ private
 
   def strip(selector)
     selector = selector.gsub(/^@.*/, '') # @-webkit-keyframes ...
-    selector = selector.gsub(/:.*/, '')  # input#x:nth-child(2):not(#z.o[type='file'])
+    selector = selector.gsub(/(?<!javascript):.*/, '')  # input#x:nth-child(2):not(#z.o[type='file']) but not a[href^="javascript:"]:after
     selector.strip
   end
 


### PR DESCRIPTION
running deadweight on 

```
# bootstrap/_print.scss

a[href^="#"]:after,
a[href^="javascript:"]:after {
    content: "";
}
```

gives following error as strip changes `a[href^="javascript:"]:after` to `a[href^="javascript` which is an invalid selector

```
gems/nokogiri-1.6.6.2/lib/nokogiri/css/parser_extras.rb:87:in `on_error': unexpected '"' after 'prefix_match' (Nokogiri::CSS::SyntaxError)
```
